### PR TITLE
Skip cid/azp validation if no cid provided

### DIFF
--- a/lib/google-id-token.rb
+++ b/lib/google-id-token.rb
@@ -110,7 +110,7 @@ module GoogleIDToken
             if currtoken['azp']
               currtoken['cid'] = currtoken['azp']
               if(currtoken.has_key?('aud') && (currtoken['aud'] == aud) &&
-                 currtoken.has_key?('cid') && (currtoken['cid'] == cid))
+                 (!cid || (currtoken.has_key?('cid') && (currtoken['cid'] == cid))))
                 # If we find a valid token, save it for further verification.
                 @token = currtoken
               end


### PR DESCRIPTION
Currently it isn't possible to skip cid validation, even though #check allows for cid to be nil. The cid/azp was still compared (to this nil value) and failed.

This allows cid to not be provided and the cid check skipped.
