### PR TITLE
Explicitly depend on jwt 1.x. It doesn't work with 0.x as of today.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/google-id-token.gemspec
+++ b/google-id-token.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.files = ['lib/google-id-token.rb', 'README.rdoc' ]
 
   s.add_runtime_dependency 'multi_json'
-  s.add_runtime_dependency 'jwt'
+  s.add_runtime_dependency 'jwt', '>= 1'
 
   s.add_development_dependency 'fakeweb'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
If you use google-id-token with JWT 0.x it raises error:

```
     Failure/Error: if currtoken['azp']

     TypeError:
       no implicit conversion of String into Integer
```

Due to the fact JWT returns a different thing than newer 1.x version


Something to consider is making the gem compatible with JWT 0.x. But that would need changes in the implementation, so maybe worth doing it as a separate pull request.