### PR TITLE
Add required param to JWT.decode

### DIFF
--- a/lib/google-id-token.rb
+++ b/lib/google-id-token.rb
@@ -112,7 +112,7 @@ module GoogleIDToken
       @certs.detect do |key, cert|
         begin
           public_key = cert.public_key
-          decoded_token = JWT.decode(token, public_key, !!public_key)
+          decoded_token = JWT.decode(token, public_key, !!public_key, { :algorithm => 'RS256' })
           payload = decoded_token.first
 
           # in Feb 2013, the 'cid' claim became the 'azp' claim per changes


### PR DESCRIPTION
JWT 2.0 gem just release. The `JWT.decode` method now requires the decoding algorithm to be specified as a parameter.