### PR TITLE
Added array comparison for aud parameter

### DIFF
--- a/lib/google-id-token.rb
+++ b/lib/google-id-token.rb
@@ -132,7 +132,7 @@ module GoogleIDToken
       end
 
       if payload
-        unless payload.has_key?('aud') &&
+        if !(payload.has_key?('aud') && Array(payload['aud']).include?(aud))
                (payload['aud'] == aud ||
                (aud.is_a?(Array) && aud.include?(payload['aud'])))
           raise AudienceMismatchError, 'Token audience mismatch'

--- a/lib/google-id-token.rb
+++ b/lib/google-id-token.rb
@@ -132,9 +132,7 @@ module GoogleIDToken
       end
 
       if payload
-        if !(payload.has_key?('aud') && Array(payload['aud']).include?(aud))
-               (payload['aud'] == aud ||
-               (aud.is_a?(Array) && aud.include?(payload['aud'])))
+        if !(payload.has_key?('aud') && Array(aud).include?(payload['aud']))
           raise AudienceMismatchError, 'Token audience mismatch'
         end
         if cid && payload['cid'] != cid

--- a/lib/google-id-token.rb
+++ b/lib/google-id-token.rb
@@ -132,7 +132,9 @@ module GoogleIDToken
       end
 
       if payload
-        if !(payload.has_key?('aud') && payload['aud'] == aud)
+        unless payload.has_key?('aud') &&
+               (payload['aud'] == aud ||
+               (aud.is_a?(Array) && aud.include?(payload['aud'])))
           raise AudienceMismatchError, 'Token audience mismatch'
         end
         if cid && payload['cid'] != cid

--- a/spec/google-id-token_spec.rb
+++ b/spec/google-id-token_spec.rb
@@ -116,6 +116,16 @@ describe GoogleIDToken::Validator do
           }.to raise_error(GoogleIDToken::ClientIDMismatchError)
         end
 
+        context 'when aud is an array' do
+          let(:aud_array) { ['123456789.apps.googleusercontent.com', '987654321.apps.googleusercontent.com'] }
+
+          it 'it checks aud against an array' do
+            expect {
+              validator.check(token, aud_array, cid)
+            }.not_to raise_error(GoogleIDToken::AudienceMismatchError)
+          end
+        end
+
         context 'when token is expired' do
           let(:exp) { Time.now - 10 }
 


### PR DESCRIPTION
The aud parameter was tested only against a string, but if a project has more than one client id all the ids aren't returned at the json. So I added a option to pass an array os a string as a aud parameter. 