### PR TITLE
Fixed Ruby warning.

### DIFF
--- a/lib/google-id-token.rb
+++ b/lib/google-id-token.rb
@@ -126,7 +126,7 @@ module GoogleIDToken
           payload
         rescue JWT::ExpiredSignature
           raise ExpiredTokenError, 'Token signature is expired'
-        rescue JWT::DecodeError => e
+        rescue JWT::DecodeError
           nil # go on, try the next cert
         end
       end


### PR DESCRIPTION
When running tests (in this repo or on others that depend on this gem)
Ruby outputs a warning: "warning: assigned but unused variable - e"

This can be seen by setting RUBYOPT="-w" when running tests or just loading code.